### PR TITLE
Support the new MsgType of GIF messages.

### DIFF
--- a/efb_qq_slave/Clients/CoolQ/CoolQ.py
+++ b/efb_qq_slave/Clients/CoolQ/CoolQ.py
@@ -440,8 +440,8 @@ class CoolQ(BaseClient):
                 msg.text = "%s%s\n\n%s" % (tgt_alias, tgt_text, coolq_text_encode(msg.text))
             msg.uid = self.coolq_send_message(chat_type[0], chat_type[1], msg.text)
             self.logger.debug('[%s] Sent as a text message. %s', msg.uid, msg.text)
-        elif msg.type in (MsgType.Image, MsgType.Sticker):
-            self.logger.info("[%s] Image/Sticker %s", msg.uid, msg.type)
+        elif msg.type in (MsgType.Image, MsgType.Sticker, MsgType.Animation):
+            self.logger.info("[%s] Image/Sticker/Animation %s", msg.uid, msg.type)
             text = ''
             if not self.client_config['is_pro']:  # CoolQ Air
                 if self.client_config['air_option']['upload_to_smms']:

--- a/efb_qq_slave/Clients/CoolQ/MsgDecorator.py
+++ b/efb_qq_slave/Clients/CoolQ/MsgDecorator.py
@@ -71,6 +71,8 @@ class QQMsgProcessor:
             mime = mime.decode()
         efb_msg.path = efb_msg.file.name
         efb_msg.mime = mime
+        if "gif" in mime:
+            efb_msg.type = MsgType.Animation
         return [efb_msg]
 
     def qq_record_wrapper(self, data):

--- a/efb_qq_slave/__init__.py
+++ b/efb_qq_slave/__init__.py
@@ -26,7 +26,7 @@ class QQMessengerChannel(EFBChannel):
     __version__ = version.__version__
 
     supported_message_types = {MsgType.Text, MsgType.Sticker, MsgType.Image,
-                               MsgType.Link, MsgType.Audio}
+                               MsgType.Link, MsgType.Audio, MsgType.Animation}
 
     # todo supported_message can be dynamically defined by Client
 


### PR DESCRIPTION
在最近的某次更新中，Telegram调整了对GIF消息的处理，导致EFB会把GIF消息分类为 `MsgType.Animation`，并且调整了 `sendPhoto` API 的工作方式，这带来了两个问题：

- 接受GIF消息时，如果将其标记为 `MsgType.Image`，Telegram收到的会是静止的图片
- 发送GIF消息时，消息会被标记为 `MsgType.Animation`，导致 `efb-qq-slave`  认为该消息属于不支持的格式，提示无法发送

我简单的调整了一下 `efb-qq-slave` 中的代码，让他能够正常处理新版本下的GIF消息。