### PR TITLE
fix smms image upload

### DIFF
--- a/efb_qq_slave/Clients/CoolQ/CoolQ.py
+++ b/efb_qq_slave/Clients/CoolQ/CoolQ.py
@@ -542,8 +542,10 @@ class CoolQ(BaseClient):
                 if self.client_config['air_option']['upload_to_smms']:
                     text = '[Image] {}'
                     smms_data = None
+                    smms_email = self.client_config['air_option']['smms_email']
+                    smms_password = self.client_config['air_option']['smms_password']
                     try:
-                        smms_data = upload_image_smms(msg.file, msg.path)
+                        smms_data = upload_image_smms(msg.file, msg.path, smms_email, smms_password)
                     except CoolQUnknownException as e:
                         text = '[Image]'
                         self.deliver_alert_to_master(self._('Failed to upload the image to sm.ms! Return Msg: ')

--- a/efb_qq_slave/Clients/CoolQ/Utils.py
+++ b/efb_qq_slave/Clients/CoolQ/Utils.py
@@ -632,12 +632,25 @@ def coolq_para_encode(text: str):  # Escape special characters for CQ Code param
     return text
 
 
-def upload_image_smms(file, path):  # Upload image to sm.ms and return the link
-    UPLOAD_URL = 'https://sm.ms/api/upload'
+def upload_image_smms(file, path, email, password):  # Upload image to sm.ms and return the link
+    UPLOAD_URL_TOKEN = 'https://sm.ms/api/v2/token'
+    UPLOAD_URL_IMAGE = 'https://sm.ms/api/v2/upload'
+    UPLOAD_LOGIN = {'username': email,
+                    'password': password}
     UPLOAD_PARAMS = {'format': 'json', 'ssl': True}
+    resp = requests.post(UPLOAD_URL_TOKEN, params=UPLOAD_LOGIN)
+    status = json.loads(resp.text)
+    if status['code'] == 'success':
+        token = status['data']['token']
+        UPLOAD_HEADER = {'Authorization': token}
+    else:
+        logging.getLogger(__name__).warning(
+                        'WARNING: {}'.format(status['msg']))
+        raise CoolQUnknownException(status['msg'])
     with open(path, 'rb') as f:
         files = {'smfile': f.read()}
-        resp = requests.post(UPLOAD_URL, files=files, params=UPLOAD_PARAMS)
+        resp = requests.post(UPLOAD_URL_IMAGE, files=files, headers=UPLOAD_HEADER,
+                             params=UPLOAD_PARAMS)
         status = json.loads(resp.text)
         if status['code'] == 'success':
             logging.getLogger(__name__).debug('INFO: upload success! url at {}'.format(status['data']['url']))


### PR DESCRIPTION
**更改:** smms上传图片的api失效，更新新的api。
**使用方法:** 
    1. 在smms注册账号
    2. 在efb_qq_slave配置文件内的air_option下添加以下配置
        smms_email:  <smms邮箱>
        smms_password: <smms密码>

**Change:** The api of smms upload pictures is invalid, update the new api.
**Instructions:** 
    1. Register an account in smms
    2. Add under air_option in the efb_qq_slave configuration file
        smms_email: <smms mailbox>
        smms_password: <smms password>