### PR TITLE
Fix image suffix missing

### DIFF
--- a/efb_qq_slave/Clients/CoolQ/CoolQ.py
+++ b/efb_qq_slave/Clients/CoolQ/CoolQ.py
@@ -801,6 +801,8 @@ class CoolQ(BaseClient):
         if self.friend_list:
             self.logger.debug('Update friend list completed. Entries: %s', len(self.friend_list))
             for friend in self.friend_list:
+                if(friend['remark']==''):
+                    friend['remark'] = friend['nickname']
                 self.friend_remark[str(friend['user_id'])] = {
                     'nickname': friend['nickname'],
                     'remark': friend['remark']

--- a/efb_qq_slave/Clients/CoolQ/MsgDecorator.py
+++ b/efb_qq_slave/Clients/CoolQ/MsgDecorator.py
@@ -16,6 +16,7 @@ from .Utils import cq_get_image, download_voice
 
 class QQMsgProcessor:
     inst: CoolQ
+    logger: logging.Logger = logging.getLogger(__name__)
 
     def __init__(self, instance: CoolQ):
         self.inst = instance
@@ -40,6 +41,7 @@ class QQMsgProcessor:
         if isinstance(mime, bytes):
             mime = mime.decode()
         efb_msg.filename = data['file'] if 'file' in data else efb_msg.file.name
+        efb_msg.filename += '.' + str(mime).split('/')[1]
         efb_msg.path = efb_msg.file.name
         efb_msg.mime = mime
         if "gif" in mime:


### PR DESCRIPTION
1.通过添加文件后缀的方式修复图像显示成文件的问题 #65 
1.Fix the problem that the image is displayed as a file by adding a file suffix #65 

2.目前marai获取好友列表 `coolq_api_query('get_friend_list')` 没有返回好友的备注(默认为''),如果备注为''则用昵称代替备注,否则不修改备注.
2. ''